### PR TITLE
Feat: 알림 UI 개선 및 동적 상대 시간 업데이트 구현

### DIFF
--- a/.devcontainer/frontend/src/components/AlertList.tsx
+++ b/.devcontainer/frontend/src/components/AlertList.tsx
@@ -13,7 +13,7 @@ interface AlertListProps {
 
 const AlertList = ({ alerts }: AlertListProps): JSX.Element => {
   return (
-    <section className="alert-list">
+    <section className="mt-6 grid grid-cols-1 divide-y-[.0625rem] divide-border_disabled border-y-[.0625rem] border-border_disabled overflow-y-auto">
       {alerts.map((alert) => (
         <AlertListItem key={alert.id} alert={alert} />
       ))}

--- a/.devcontainer/frontend/src/components/AlertListItem.tsx
+++ b/.devcontainer/frontend/src/components/AlertListItem.tsx
@@ -1,4 +1,26 @@
+import { useEffect, useState } from "react";
 import AlertIcon from "../assets/alertNoneIcon.svg?react";
+
+const getRelativeTime = (dateString: string) => {
+  const now = new Date();
+  const date = new Date(dateString);
+  const difference = now.getTime() - date.getTime(); // 밀리초 차이 계산
+
+  const seconds = Math.floor(difference / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) {
+    return `${days}일 전`;
+  } else if (hours > 0) {
+    return `${hours}시간 전`;
+  } else if (minutes > 0) {
+    return `${minutes}분 전`;
+  } else {
+    return `방금 전`;
+  }
+};
 
 interface AlertProps {
   alert: {
@@ -10,6 +32,18 @@ interface AlertProps {
 }
 
 const AlertListItem = ({ alert }: AlertProps): JSX.Element => {
+  const [_, setForceUpdate] = useState(0);
+
+  useEffect(() => {
+    // 1분마다 컴포넌트 리렌더링
+    const interval = setInterval(() => {
+      setForceUpdate((prev) => prev + 1); // 상태 업데이트를 통해 리렌더링 트리거
+    }, 60000);
+
+    // 컴포넌트 언마운트 시 interval 클리어
+    return () => clearInterval(interval);
+  }, []);
+
   return (
     <div className="flex w-full px-4 py-5 gap-x-4">
       <AlertIcon />
@@ -20,7 +54,9 @@ const AlertListItem = ({ alert }: AlertProps): JSX.Element => {
         <p className="text-text_default text-[.9375rem] truncate">
           {alert.message}
         </p>
-        <p className="text-text_info text-[.8125rem]">{alert.date}</p>
+        <p className="text-text_info text-[.8125rem]">
+          {getRelativeTime(alert.date)}
+        </p>
       </div>
     </div>
   );

--- a/.devcontainer/frontend/src/components/AlertListItem.tsx
+++ b/.devcontainer/frontend/src/components/AlertListItem.tsx
@@ -1,3 +1,5 @@
+import AlertIcon from "../assets/alertNoneIcon.svg?react";
+
 interface AlertProps {
   alert: {
     id: number;
@@ -9,48 +11,17 @@ interface AlertProps {
 
 const AlertListItem = ({ alert }: AlertProps): JSX.Element => {
   return (
-    <div className="flex flex-col justify-start items-center flex-grow-0 w-full left-10 top-[84px] gap-6">
-      <div className="flex flex-col justify-start items-start self-stretch flex-grow-0 flex-shrink-0 gap-3">
-        <div className="flex justify-start items-start self-stretch flex-grow-0 flex-shrink-0 relative gap-2.5 px-4">
-          <p className="flex-grow-0 flex-shrink-0 text-[15px] font-bold text-left text-[#444]">
-            {alert.date}
-          </p>
-        </div>
-        <div className="flex flex-col justify-start items-start self-stretch flex-grow-0 flex-shrink-0">
-          <div className="flex justify-start items-start self-stretch flex-grow-0 flex-shrink-0 relative gap-4 px-4 py-5 rounded-xl bg-white border-2 border-[#efefef]">
-            <div className="flex flex-col justify-center items-start flex-grow-0 flex-shrink-0 relative overflow-hidden">         
-            <div className="flex justify-center items-center w-10 h-10 relative overflow-hidden rounded-full bg-[#bfbfbf]">
-              <p className="text-base font-medium text-center text-white">
-                  A
-                </p>
-              </div>
-            </div>
-            <div className="flex flex-col justify-center items-start self-stretch w-[940px] relative overflow-hidden gap-1">
-              <p className="self-stretch text-base font-bold text-left text-[#232527]">
-                {alert.title}
-              </p>
-              <p className="self-stretch text-base text-left text-[#232527]">
-                {alert.message}
-              </p>
-              <p className="self-stretch text-[13px] text-left text-[#777]">
-                1분 전
-              </p>
-            </div>
-            <svg
-              width={12}
-              height={12}
-              viewBox="0 0 12 12"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              className="flex-grow-0 flex-shrink-0 absolute"
-              style={{ left: '97.34%', top: '16.66%' }}
-              preserveAspectRatio="xMidYMid meet"
-            >
-              <circle cx={6} cy={6} r={6} fill="#FF0101" />
-            </svg>
-          </div>
-        </div>
-      </div>   
+    <div className="flex w-full px-4 py-5 gap-x-4">
+      <AlertIcon />
+      <div className="flex flex-col flex-1 overflow-hidden gap-y-1">
+        <p className="text-text_default text-[.9375rem] font-bold truncate">
+          {alert.title}
+        </p>
+        <p className="text-text_default text-[.9375rem] truncate">
+          {alert.message}
+        </p>
+        <p className="text-text_info text-[.8125rem]">{alert.date}</p>
+      </div>
     </div>
   );
 };

--- a/.devcontainer/frontend/src/pages/Alert.tsx
+++ b/.devcontainer/frontend/src/pages/Alert.tsx
@@ -2,16 +2,51 @@ import { useState, useEffect } from "react";
 import NoAlertIcon from "../assets/alertNoneIcon.svg?react";
 import SortButton from "../components/SortButton";
 import AlertList from "../components/AlertList";
-import useAlertStore from "../stores/alertStore";
+// import useAlertStore from "../stores/alertStore";
+
+const mockAlerts = [
+  {
+    id: 1,
+    title: "새로운 공지사항",
+    message: "새로운 공지사항이 있습니다.",
+    date: "2024-09-10T10:30:00Z",
+  },
+  {
+    id: 2,
+    title: "이벤트 알림",
+    message:
+      "이벤트 참여하세요!🎉 이벤트 참여하세요!🎊 이벤트 참여하세요!🎉 이벤트 참여하세요!🎊 이벤트 참여하세요!🎉 이벤트 참여하세요!🎊 이벤트 참여하세요!🎉 이벤트 참여하세요!🎊 ",
+    date: "2024-09-14T12:12:00Z",
+  },
+  {
+    id: 3,
+    title: "업데이트 알림",
+    message: "A 기능 지원이 중단되었습니다.",
+    date: "2024-09-06T09:00:00Z",
+  },
+  {
+    id: 4,
+    title: "업데이트 알림",
+    message: "업데이트 내용을 확인하세요.",
+    date: "2024-09-09T15:45:00Z",
+  },
+  {
+    id: 5,
+    title: "새로운 공지사항",
+    message: "닉네임 설정 기능이 생겼어요!",
+    date: "2024-09-13T19:00:00Z",
+  },
+];
 
 const Alert = (): JSX.Element => {
-  const alertList = useAlertStore((state) => state.alerts);
-  const fetchAlerts = useAlertStore((state) => state.fetchAlerts);
+  // const alertList = useAlertStore((state) => state.alerts);
+  // const fetchAlerts = useAlertStore((state) => state.fetchAlerts);
+  const [alertList, setAlertList] = useState(mockAlerts);
   const [sortOrder, setSortOrder] = useState<"latest" | "oldest">("latest");
 
-  useEffect(() => {
-    fetchAlerts();
-  }, [fetchAlerts]);
+  // useEffect(() => {
+  //   fetchAlerts();
+  // }, [fetchAlerts]);
 
   const sortedAlerts = [...alertList].sort((a, b) => {
     return sortOrder === "latest"
@@ -21,9 +56,9 @@ const Alert = (): JSX.Element => {
 
   return (
     <div className="flex justify-center">
-      <div className="w-[900px] my-10 flex flex-col gap-y-4">
+      <div className="w-[56.25rem] my-10 flex flex-col gap-y-4">
         <p className="text-lg font-extrabold">내 소식</p>
-        <div className="min-h-[535px] p-6 flex flex-col bg-white rounded-xl drop-shadow-[0_5px_5px_rgba(0,0,0,0.1)]">
+        <div className="min-h-[33.4375rem] p-6 flex flex-col bg-white rounded-xl drop-shadow-[0_.3125rem_.3125rem_rgba(0,0,0,0.1)]">
           {/* 정렬 버튼 */}
           <div className="flex justify-end gap-4">
             <SortButton
@@ -39,17 +74,23 @@ const Alert = (): JSX.Element => {
               onClick={() => setSortOrder("oldest")}
             />
           </div>
-          {/* TODO) 소식 여부에 따른 조건부 렌더링 구현 필요 */}
-          <div className="w-full h-full">
+
+          {/* 알림 item */}
+          <div
+            className={`w-full h-[28.125rem] flex flex-col gap-y-4 ${sortedAlerts.length ? "" : "justify-center items-center"}`}
+          >
             {/* 소식 없을 때 */}
-            <div className="w-full h-full flex flex-col justify-center items-center gap-y-4">
-              <NoAlertIcon />
-              <p className="text-sm text-text_info">새로운 소식이 없습니다.</p>
-            </div>
+            {!sortedAlerts.length && (
+              <>
+                <NoAlertIcon />
+                <p className="text-sm text-text_info">
+                  최근 30일동안 받은 알림이 없어요
+                </p>
+              </>
+            )}
+
             {/* 소식 있을 때 */}
-            <div className="w-full h-full flex flex-col">
-              <AlertList alerts={sortedAlerts} />
-            </div>
+            {sortedAlerts.length > 0 && <AlertList alerts={sortedAlerts} />}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🌱 구현 내용

1. **알림 UI 개선 및 조건부 렌더링 추가**

    - 알림이 없을 때와 있을 때의 조건부 렌더링 추가
    - `AlertList` 및 `AlertListItem`의 UI 및 스타일링 개선
    - 전역 상태 관리 대신 `mockAlerts`를 사용하여 UI 테스트 및 개발 (`useAlertStore` 주석 처리)
    - 알림 리스트에 스크롤 적용
    - 단위 변환 (px to rem)

2. **알림에 대한 동적 상대 시간 업데이트 추가**

    - 현재 시간과 알림 등록 시간 차이를 계산하는 `getRelativeTime()` 함수 구현
      - `getRelativeTime()`는 '방금 전', '1분 전', '2시간 전', '3일 전' 등의 문장을 반환
    - 1분마다 상대 시간을 업데이트하기 위해 `setInterval` 사용
 
## 🌱 변경 전후 UI

**변경 전**
  <img width="1552" alt="image" src="https://github.com/user-attachments/assets/340ff6de-1ae0-4232-b284-4e17bd335451">


**변경 후**
  <table border="0" >
      <tr>
          <td><img width="1552" alt="image" src="https://github.com/user-attachments/assets/fe996799-0cc3-412a-aebc-16300a811a90"></td>
          <td><img width="1552" alt="image" src="https://github.com/user-attachments/assets/fc96cde1-d50c-4a84-8b1a-b26e289f5441"></td>
      </tr>
      </table>


## 🌱 추후 구현할 사항

- `zustand`를 통해 `AlertListItem` 컴포넌트의 상대 시간을 전역적으로 관리하여 효율적인 리렌더링을 구현할 예정
  - 현재 코드에서는 각 `AlertListItem` 컴포넌트가 자체적으로 `setInterval`을 사용하여 1분마다 상대 시간을 업데이트 (컴포넌트마다 `setInterval`이 독립적으로 실행됨)
  - **따라서 각 `AlertListItem` 컴포넌트가 1분이 지날 때마다 개별적으로 리렌더링을 트리거하기 때문에, 생성 시간과 현재 시간의 차이가 1분 늘어날 때마다 리렌더링이 발생** → 성능면에서 비효율적
-  백엔드 연동 후 `MockAlerts` 제거