### PR TITLE
Fix: DiaryContentInput 컴포넌트 입력 오류 수정

### DIFF
--- a/.devcontainer/frontend/src/components/DiaryContentInput.tsx
+++ b/.devcontainer/frontend/src/components/DiaryContentInput.tsx
@@ -1,14 +1,19 @@
+import { useState } from "react";
+
 interface DiaryContentInputProps {
   value: string;
   onChange: (value: string) => void;
 }
 
 const MAX_ROWS = 3;
+const MAX_LENGTH = 75;
 
 const DiaryContentInput = ({
   value,
   onChange,
 }: DiaryContentInputProps): JSX.Element => {
+  const [charCount, setCharCount] = useState(value.length);
+
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const inputValue = event.target.value;
 
@@ -18,6 +23,7 @@ const DiaryContentInput = ({
       return;
     }
 
+    setCharCount(inputValue.length);
     onChange(inputValue);
   };
 
@@ -34,7 +40,7 @@ const DiaryContentInput = ({
   const lineHeights = [2.9688, 2.9375, 2.9688]; // 줄 배경 높이 (divider가 1px임을 고려)
 
   return (
-    <div className="relative w-full h-[9rem]">
+    <div className="relative w-full">
       {/* 줄 배경 */}
       <div className="absolute h-fit border border-divider_default divide-y divide-divider_default inset-0 pointer-events-none z-10">
         {lineHeights.map((height, index) => (
@@ -53,7 +59,11 @@ const DiaryContentInput = ({
         className="relative w-full resize-none px-5 font-ownglyph text-lg leading-[3rem] text-text_default placeholder-text_disabled tracking-widest focus:outline-none"
         placeholder="오늘 하루를 자유롭게 작성해 보세요."
         rows={MAX_ROWS}
+        maxLength={MAX_LENGTH}
       />
+      <p className="w-full text-right text-text_disabled text-sm font-ownglyph tracking-widest">
+        {charCount} / {MAX_LENGTH}
+      </p>
     </div>
   );
 };

--- a/.devcontainer/frontend/src/components/DiaryContentInput.tsx
+++ b/.devcontainer/frontend/src/components/DiaryContentInput.tsx
@@ -1,118 +1,36 @@
-import React, { useState, useRef, useEffect } from "react";
-
 interface DiaryContentInputProps {
   value: string[];
   onChange: (value: string[]) => void;
 }
 
-const DiaryContentInput: React.FC<DiaryContentInputProps> = ({
+const DiaryContentInput = ({
   value,
   onChange,
-}) => {
-  const placeholderText = "오늘 하루를 자유롭게 작성해 보세요";
-  const initialContent = value.length
-    ? value
-    : placeholderText
-        .split("")
-        .concat(Array(60 - placeholderText.length).fill(""));
+}: DiaryContentInputProps): JSX.Element => {
+  const MAX_ROWS = 3;
 
-  const [content, setContent] = useState<string[]>(initialContent);
-  const [isPlaceholderActive, setIsPlaceholderActive] = useState(true);
-  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
-
-  useEffect(() => {
-    if (value.length) {
-      setContent(value);
-      setIsPlaceholderActive(false);
-    }
-  }, [value]);
-
-  const handleChange = (index: number, val: string) => {
-    const newContent = [...content];
-    newContent[index] = val;
-    setContent(newContent);
-    onChange(newContent); // Propagate the change to the parent component
-  };
-
-  const handleFocus = (index: number) => {
-    if (isPlaceholderActive) {
-      setContent(Array(60).fill(""));
-      setIsPlaceholderActive(false);
-    }
-    inputRefs.current[index]?.focus();
-  };
-
-  const handleCompositionEnd = (index: number) => {
-    if (index < 59) {
-      inputRefs.current[index + 1]?.focus();
-    }
-  };
-
-  const handleKeyDown = (index: number, event: React.KeyboardEvent) => {
-    if (event.key === "Backspace") {
-      if (content[index] === "" && index > 0) {
-        inputRefs.current[index - 1]?.focus();
-      }
-    }
-  };
-
-  const renderCells = () => {
-    return content.map((char, index) => {
-      const x = 26 + (index % 10) * 52;
-      const y = 26 + Math.floor(index / 10) * 52;
-      const isPlaceholder =
-        isPlaceholderActive && index < placeholderText.length;
-
-      return (
-        <foreignObject key={index} x={x - 20} y={y - 20} width={40} height={40}>
-          <input
-            ref={(el) => (inputRefs.current[index] = el)}
-            type="text"
-            value={content[index]}
-            maxLength={1}
-            onChange={(e) => handleChange(index, e.target.value)}
-            onFocus={() => handleFocus(index)}
-            onKeyDown={(e) => handleKeyDown(index, e)}
-            onCompositionEnd={() => handleCompositionEnd(index)}
-            className={`w-full h-full text-center bg-transparent border-none outline-none font-ownglyph text-[24px] ${
-              isPlaceholder ? "text-[#a0a0a0]" : "text-[#232527]"
-            }`}
-          />
-        </foreignObject>
-      );
-    });
+  // 줄 변경 핸들러
+  const handleLineChange = (index: number, newValue: string) => {
+    const newLines = [...value];
+    newLines[index] = newValue;
+    onChange(newLines);
   };
 
   return (
-    <div className="relative w-[520px] h-[313px]">
-      <svg
-        width={520}
-        height={313}
-        viewBox="0 0 520 313"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        className="absolute top-0 left-0"
-        preserveAspectRatio="none"
-      >
-        <rect x="0.5" y="0.5" width={519} height={312} stroke="#E2E2E2" />
-        <path d="M208 0L208 312" stroke="#E2E2E2" />
-        <path d="M260 0L260 312" stroke="#E2E2E2" />
-        <path d="M312 0L312 312" stroke="#E2E2E2" />
-        <path d="M364 0L364 312" stroke="#E2E2E2" />
-        <path d="M416 0L416 312" stroke="#E2E2E2" />
-        <path d="M468 0L468 312" stroke="#E2E2E2" />
-        <path d="M156 0L156 312" stroke="#E2E2E2" />
-        <path d="M104 0L104 312" stroke="#E2E2E2" />
-        <path d="M52 0L52 312" stroke="#E2E2E2" />
-        <path d="M520 52L0 52" stroke="#E2E2E2" />
-        <path d="M520 104L0 104" stroke="#E2E2E2" />
-        <path d="M520 156L0 156" stroke="#E2E2E2" />
-        <path d="M520 208L0 208" stroke="#E2E2E2" />
-        <path d="M520 260L0 260" stroke="#E2E2E2" />
-
-        {/* 각 격자 칸을 input으로 만들어 렌더링 */}
-        {renderCells()}
-      </svg>
+    <div className="w-full border border-divider_default divide-y divide-divider_default">
+      {Array.from({ length: MAX_ROWS }).map((_, index) => (
+        <div key={index} className="relative w-full">
+          <input
+            type="text"
+            value={value[index] || ""}
+            onChange={(e) => handleLineChange(index, e.target.value)}
+            placeholder={
+              index === 0 ? "오늘 하루를 자유롭게 작성해 보세요." : ""
+            }
+            className="w-full px-5 py-3 font-ownglyph text-lg text-text_default placeholder-text_disabled tracking-widest focus:outline-none"
+          />
+        </div>
+      ))}
     </div>
   );
 };

--- a/.devcontainer/frontend/src/components/DiaryContentInput.tsx
+++ b/.devcontainer/frontend/src/components/DiaryContentInput.tsx
@@ -15,36 +15,35 @@ const DiaryContentInput = ({
   const [charCount, setCharCount] = useState(value.length);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const inputValue = event.target.value;
-
-    const lines = inputValue.split("\n").length; // 입력된 내용에서 줄 수 확인
-    const textarea = textareaRef.current;
-
-    if (textarea) {
-      const { scrollHeight, clientHeight } = textarea;
-
-      // 스크롤이 발생하면 입력 제한
-      // 행 수 제한, 글자 수 제한
-      if (
-        scrollHeight > clientHeight ||
-        lines > MAX_ROWS ||
-        inputValue.length > MAX_LENGTH
-      ) {
-        return;
-      }
-    }
-    setCharCount(inputValue.length);
-    onChange(inputValue);
+  // 줄 수 초과하면 추가 입력 차단
+  const isLineLimitExceeded = (inputValue: string) => {
+    const lines = inputValue.split("\n").length;
+    return lines > MAX_ROWS;
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    const lines = value.split("\n").length; // 현재 내용에서 줄 수 확인
-
-    // MAX_ROWS를 초과하는 경우 Enter 키 입력 막음
-    if (event.key === "Enter" && lines >= MAX_ROWS) {
-      event.preventDefault();
+  // 스크롤 발생하려는 상황에서 입력 차단
+  const isScrollLimitExceeded = () => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      const { scrollHeight, clientHeight } = textarea;
+      return scrollHeight > clientHeight;
     }
+    return false;
+  };
+
+  const handleInput = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const inputValue = event.target.value;
+
+    if (
+      isLineLimitExceeded(inputValue) ||
+      isScrollLimitExceeded() ||
+      inputValue.length > MAX_LENGTH
+    ) {
+      return;
+    }
+
+    setCharCount(inputValue.length);
+    onChange(inputValue);
   };
 
   const lineHeights = [2.9688, 2.9375, 2.9688]; // 줄 배경 높이 (divider가 1px임을 고려)
@@ -65,8 +64,7 @@ const DiaryContentInput = ({
       <textarea
         ref={textareaRef}
         value={value}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
+        onChange={handleInput}
         className="relative w-full max-h-36 overflow-hidden resize-none px-5 font-ownglyph text-lg leading-[3rem] text-text_default placeholder-text_disabled tracking-widest focus:outline-none"
         placeholder="오늘 하루를 자유롭게 작성해 보세요."
         rows={MAX_ROWS}

--- a/.devcontainer/frontend/src/components/DiaryContentInput.tsx
+++ b/.devcontainer/frontend/src/components/DiaryContentInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 interface DiaryContentInputProps {
   value: string;
@@ -13,26 +13,36 @@ const DiaryContentInput = ({
   onChange,
 }: DiaryContentInputProps): JSX.Element => {
   const [charCount, setCharCount] = useState(value.length);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const inputValue = event.target.value;
 
-    const lines = inputValue.split("\n"); // 입력된 내용에서 줄 수 확인
+    const lines = inputValue.split("\n").length; // 입력된 내용에서 줄 수 확인
+    const textarea = textareaRef.current;
 
-    if (lines.length > MAX_ROWS) {
-      return;
+    if (textarea) {
+      const { scrollHeight, clientHeight } = textarea;
+
+      // 스크롤이 발생하면 입력 제한
+      // 행 수 제한, 글자 수 제한
+      if (
+        scrollHeight > clientHeight ||
+        lines > MAX_ROWS ||
+        inputValue.length > MAX_LENGTH
+      ) {
+        return;
+      }
     }
-
     setCharCount(inputValue.length);
     onChange(inputValue);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    const lines = value.split("\n"); // 현재 내용에서 줄 수 확인
-    console.log(lines.length);
+    const lines = value.split("\n").length; // 현재 내용에서 줄 수 확인
 
     // MAX_ROWS를 초과하는 경우 Enter 키 입력 막음
-    if (event.key === "Enter" && lines.length >= MAX_ROWS) {
+    if (event.key === "Enter" && lines >= MAX_ROWS) {
       event.preventDefault();
     }
   };
@@ -53,10 +63,11 @@ const DiaryContentInput = ({
       </div>
 
       <textarea
+        ref={textareaRef}
         value={value}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
-        className="relative w-full resize-none px-5 font-ownglyph text-lg leading-[3rem] text-text_default placeholder-text_disabled tracking-widest focus:outline-none"
+        className="relative w-full max-h-36 overflow-hidden resize-none px-5 font-ownglyph text-lg leading-[3rem] text-text_default placeholder-text_disabled tracking-widest focus:outline-none"
         placeholder="오늘 하루를 자유롭게 작성해 보세요."
         rows={MAX_ROWS}
         maxLength={MAX_LENGTH}

--- a/.devcontainer/frontend/src/components/DiaryContentInput.tsx
+++ b/.devcontainer/frontend/src/components/DiaryContentInput.tsx
@@ -1,36 +1,59 @@
 interface DiaryContentInputProps {
-  value: string[];
-  onChange: (value: string[]) => void;
+  value: string;
+  onChange: (value: string) => void;
 }
+
+const MAX_ROWS = 3;
 
 const DiaryContentInput = ({
   value,
   onChange,
 }: DiaryContentInputProps): JSX.Element => {
-  const MAX_ROWS = 3;
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const inputValue = event.target.value;
 
-  // 줄 변경 핸들러
-  const handleLineChange = (index: number, newValue: string) => {
-    const newLines = [...value];
-    newLines[index] = newValue;
-    onChange(newLines);
+    const lines = inputValue.split("\n"); // 입력된 내용에서 줄 수 확인
+
+    if (lines.length > MAX_ROWS) {
+      return;
+    }
+
+    onChange(inputValue);
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const lines = value.split("\n"); // 현재 내용에서 줄 수 확인
+    console.log(lines.length);
+
+    // MAX_ROWS를 초과하는 경우 Enter 키 입력 막음
+    if (event.key === "Enter" && lines.length >= MAX_ROWS) {
+      event.preventDefault();
+    }
+  };
+
+  const lineHeights = [2.9688, 2.9375, 2.9688]; // 줄 배경 높이 (divider가 1px임을 고려)
+
   return (
-    <div className="w-full border border-divider_default divide-y divide-divider_default">
-      {Array.from({ length: MAX_ROWS }).map((_, index) => (
-        <div key={index} className="relative w-full">
-          <input
-            type="text"
-            value={value[index] || ""}
-            onChange={(e) => handleLineChange(index, e.target.value)}
-            placeholder={
-              index === 0 ? "오늘 하루를 자유롭게 작성해 보세요." : ""
-            }
-            className="w-full px-5 py-3 font-ownglyph text-lg text-text_default placeholder-text_disabled tracking-widest focus:outline-none"
-          />
-        </div>
-      ))}
+    <div className="relative w-full h-[9rem]">
+      {/* 줄 배경 */}
+      <div className="absolute h-fit border border-divider_default divide-y divide-divider_default inset-0 pointer-events-none z-10">
+        {lineHeights.map((height, index) => (
+          <div
+            key={index}
+            className="w-full"
+            style={{ height: `${height}rem` }}
+          ></div>
+        ))}
+      </div>
+
+      <textarea
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        className="relative w-full resize-none px-5 font-ownglyph text-lg leading-[3rem] text-text_default placeholder-text_disabled tracking-widest focus:outline-none"
+        placeholder="오늘 하루를 자유롭게 작성해 보세요."
+        rows={MAX_ROWS}
+      />
     </div>
   );
 };

--- a/.devcontainer/frontend/src/components/DiaryTitleInput.tsx
+++ b/.devcontainer/frontend/src/components/DiaryTitleInput.tsx
@@ -14,15 +14,13 @@ const DiaryTitleInput: React.FC<DiaryTitleInputProps> = ({
   };
 
   return (
-    <div className="flex justify-start items-center flex-grow-0 flex-shrink-0 w-[520px] relative gap-2.5 px-5 py-3 border border-[#e2e2e2]">
-      <input
-        type="text"
-        value={value}
-        onChange={handleChange}
-        placeholder="제목을 입력해 주세요"
-        className="w-full text-lg text-[#232527] font-ownglyph placeholder-[#a0a0a0] focus:outline-none"
-      />
-    </div>
+    <input
+      type="text"
+      value={value}
+      onChange={handleChange}
+      placeholder="제목을 입력해 주세요"
+      className="w-full px-5 py-3 border border-divider_default font-ownglyph text-lg text-text_default placeholder-text_disabled tracking-widest focus:outline-none"
+    />
   );
 };
 

--- a/.devcontainer/frontend/src/components/DiaryTitleInput.tsx
+++ b/.devcontainer/frontend/src/components/DiaryTitleInput.tsx
@@ -5,10 +5,10 @@ interface DiaryTitleInputProps {
   onChange: (value: string) => void;
 }
 
-const DiaryTitleInput: React.FC<DiaryTitleInputProps> = ({
+const DiaryTitleInput = ({
   value,
   onChange,
-}) => {
+}: DiaryTitleInputProps): JSX.Element => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(e.target.value);
   };


### PR DESCRIPTION
## 🌱 구현 내용

1. **DiaryTitleInput, DiaryContentInput 컴포넌트 구조 및 스타일 개선**
    - **DiaryTitleInput**
        - 불필요한 래퍼 제거
        
    - **DiaryContentInput**
        - 레이아웃을 10x6 격자 모양에서 3행의 줄글 모양으로 변경 (디자인 2안 적용)
            - textarea와 줄 배경 스타일을 위한 div를 통해 디자인을 반영하면서도 다중 줄 입력을 지원
            - 일기 내용을 관리하는 방식을 문자열 배열(`string[]`)에서 단일 문자열(`string`)로 변경
            
        - textarea에 실시간 글자수 표시 기능 구현

2. **DiaryContentInput의 textarea 줄 수 제한 및 스크롤 방지**
    - 기존에는 `rows={MAX_ROWS}`, `if (lines.length > MAX_ROWS) return;`을 통해 줄 수를 제한했으나, 줄바꿈 없이 글이 연속적으로 입력되면 MAX_ROWS를 초과하여 스크롤되는 문제가 있었음.
    
        - `useRef`로 `textarea` 요소에 접근해 `scrollHeight`와 `clientHeight`를 비교하여 스크롤이 발생하면 입력을 차단하는 로직을 추가해 해결
        - `textarea`의 최대 높이를 설정하고, `overflow-hidden`을 적용하여 줄바꿈 및 스크롤 방지

3. **입력 제한 로직 분리 및 입력 처리 리팩토링**

    - `handleChange`와 `handleKeyDown`에 중복으로 작성된 줄 수 제한 로직 제거
    
    - 줄 수 제한 및 스크롤 제한 로직을 각각 `isLineLimitExceeded`, `isScrollLimitExceeded` 함수로 분리
    - `handleChange`와 `handleKeyDown`을 `handleInput` 함수로 통합하여 입력 처리 로직 관리
    - `handleInput` 함수가 줄 수 제한 및 엔터 키 입력 차단 역할을 수행하므로 `onKeyDown` 속성 제거

## 🌱 변경 전후 UI

### 변경 전

![2024-09-246 55 03-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f3693ad6-445e-4482-979e-bb913f6c1892)

### 변경 후

![2024-09-247 41 11-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/fda09241-f0c9-4d09-926a-ea5818541d46)
